### PR TITLE
Avoid NPE by setting output directory if unspecified

### DIFF
--- a/src/main/java/ca/mcgill/cs/crown/data/WiktionaryReader.java
+++ b/src/main/java/ca/mcgill/cs/crown/data/WiktionaryReader.java
@@ -64,9 +64,12 @@ import edu.mit.jwi.item.POS;
 public class WiktionaryReader {
 
     public List<LexicalEntry> loadFromDump(File wiktionaryXmlDump,
-                                           File outputWiktionaryDir,
+                                           File owd,
                                            File outputPreprocessedFile)
             throws IOException {
+
+        // Use the parent directory of outputPreprocessedFile for output if unspecified
+        File outputWiktionaryDir = (owd != null) ? owd : outputPreprocessedFile.getParentFile();
 
         // Sanity check that we're not needlessly extracting from the dump file
         // by seeing if the directory already contains the extracted data


### PR DESCRIPTION
`WiktionaryReader` expects the output directory to be specified.

```
Compiling the CROWN Build
java.lang.NullPointerException
    at ca.mcgill.cs.crown.data.WiktionaryReader.loadFromDump(WiktionaryReader.java:73)
    at ca.mcgill.cs.crown.CrownCreator.main(CrownCreator.java:556)
Finished!
```

This commit sets the output directory to the parent directory of the preprocessed wiktionary file whenever the output directory is left unspecified.
