### PR TITLE
Fixed compile error related to type mismatch.

### DIFF
--- a/src/main/java/ca/mcgill/cs/crown/similarity/InvFreqSimilarity.java
+++ b/src/main/java/ca/mcgill/cs/crown/similarity/InvFreqSimilarity.java
@@ -87,8 +87,7 @@ public class InvFreqSimilarity implements SimilarityFunction {
 
         lemmaToWeight = new TObjectDoubleHashMap<String>(entries.size());
         // NOTE: make this some kind of proper cache?
-        stringToLemmasCache = new HashMultiMap<String,String>(500_000);
-    
+        stringToLemmasCache = new HashMultiMap<String,String>();
         java.util.Properties props = new java.util.Properties();
         props.put("annotators", "tokenize, ssplit, pos, lemma");
         pipeline = new StanfordCoreNLP(props);


### PR DESCRIPTION
This commit "fixes" this compile error:

```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/gus/repos/crown/src/main/java/ca/mcgill/cs/crown/similarity/InvFreqSimilarity.java:[90,63] incompatible types: int cannot be converted to java.util.Map<? extends java.lang.String,? extends java.lang.String>
[INFO] 1 error
```

It looks like the max size of `HashMultiMap` cannot be specified, at least not in the way it was being done?
