### PR TITLE
Avoid NPE by adding null check prior to attempt to fold the case of lemma

### DIFF
--- a/src/main/java/ca/mcgill/cs/crown/procedure/ParseExtractor.java
+++ b/src/main/java/ca/mcgill/cs/crown/procedure/ParseExtractor.java
@@ -272,15 +272,15 @@ public class ParseExtractor implements EnrichmentProcedure {
         next_root:
         for (IndexedWord root : roots) {
             String word = root.get(TextAnnotation.class);
-            String lemma = root.get(LemmaAnnotation.class);
+            String lm = root.get(LemmaAnnotation.class);
             String pos = root.get(PartOfSpeechAnnotation.class);
             char lemmaPos = pos.substring(0,1).toLowerCase().charAt(0);
-            
-            String lemmaLc = lemma.toLowerCase();
+
+            // null check
+            String lemma = (lm != null) ? lm.toLowerCase() : "";
 
             //System.out.println("testing: " + lemma + "/" + pos);
-            
-            
+
             // If the lemma is a verb, check for phrasal verbal particle (e.g.,
             // "lead on", "edge out") and if present, add them to the lemma
             if (lemmaPos == 'v') {


### PR DESCRIPTION
I was running into this error:

```
java.lang.NullPointerException
    at ca.mcgill.cs.crown.procedure.ParseExtractor.getCandidates(ParseExtractor.java:279)
    at ca.mcgill.cs.crown.procedure.ParseExtractor.getCandidateHypernyms(ParseExtractor.java:219)
    at ca.mcgill.cs.crown.procedure.ParseExtractor.integrate(ParseExtractor.java:89)
    at ca.mcgill.cs.crown.BuildPipeline.integrate(BuildPipeline.java:89)
    at ca.mcgill.cs.crown.CrownCreator.tryIntegrate(CrownCreator.java:315)
    at ca.mcgill.cs.crown.CrownCreator.lambda$foobar$0(CrownCreator.java:289)
    at ca.mcgill.cs.crown.CrownCreator$$Lambda$9/2116287996.accept(Unknown Source)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1374)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:512)
    at java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
    at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
    at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:902)
    at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1689)
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1644)
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

It looks like `lemmaLc` was not being used, but its instantiation was causing this error.  I changed things to fold the case of the lemma safely.  I think this only matters when CoreNLP fails to properly lemmatize something.
